### PR TITLE
Convert Color into an enum

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -1,52 +1,54 @@
 /// A color
 #[derive(Copy, Clone)]
-#[repr(packed)]
-pub struct Color {
-    pub data: u32,
+pub enum Color {
+    Ansi(u8),
+    TrueColor(u8, u8, u8),
 }
 
 impl Color {
-    /// Create a new color from RGB
-    pub fn new(r: u8, g: u8, b: u8) -> Self {
-        Color { data: 0xFF000000 | ((r as u32) << 16) | ((g as u32) << 8) | (b as u32) }
-    }
+    pub fn as_rgb(&self) -> u32 {
+        let encode_rgb = |r: u8, g: u8, b: u8| -> u32 {
+            0xFF000000 | ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
+        };
 
-    pub fn ansi(value: u8) -> Self {
-        match value {
-            0 => Color::new(0x00, 0x00, 0x00),
-            1 => Color::new(0x80, 0x00, 0x00),
-            2 => Color::new(0x00, 0x80, 0x00),
-            3 => Color::new(0x80, 0x80, 0x00),
-            4 => Color::new(0x00, 0x00, 0x80),
-            5 => Color::new(0x80, 0x00, 0x80),
-            6 => Color::new(0x00, 0x80, 0x80),
-            7 => Color::new(0xc0, 0xc0, 0xc0),
-            8 => Color::new(0x80, 0x80, 0x80),
-            9 => Color::new(0xff, 0x00, 0x00),
-            10 => Color::new(0x00, 0xff, 0x00),
-            11 => Color::new(0xff, 0xff, 0x00),
-            12 => Color::new(0x00, 0x00, 0xff),
-            13 => Color::new(0xff, 0x00, 0xff),
-            14 => Color::new(0x00, 0xff, 0xff),
-            15 => Color::new(0xff, 0xff, 0xff),
-            16 ... 231 => {
-                let convert = |value: u8| -> u8 {
-                    match value {
-                        0 => 0,
-                        _ => value * 0x28 + 0x28
-                    }
-                };
+        match *self {
+            Color::TrueColor(r, g, b) => encode_rgb(r, g, b),
+            Color::Ansi(value) => match value {
+                0 => encode_rgb(0x00, 0x00, 0x00),
+                1 => encode_rgb(0x80, 0x00, 0x00),
+                2 => encode_rgb(0x00, 0x80, 0x00),
+                3 => encode_rgb(0x80, 0x80, 0x00),
+                4 => encode_rgb(0x00, 0x00, 0x80),
+                5 => encode_rgb(0x80, 0x00, 0x80),
+                6 => encode_rgb(0x00, 0x80, 0x80),
+                7 => encode_rgb(0xc0, 0xc0, 0xc0),
+                8 => encode_rgb(0x80, 0x80, 0x80),
+                9 => encode_rgb(0xff, 0x00, 0x00),
+                10 => encode_rgb(0x00, 0xff, 0x00),
+                11 => encode_rgb(0xff, 0xff, 0x00),
+                12 => encode_rgb(0x00, 0x00, 0xff),
+                13 => encode_rgb(0xff, 0x00, 0xff),
+                14 => encode_rgb(0x00, 0xff, 0xff),
+                15 => encode_rgb(0xff, 0xff, 0xff),
+                16 ... 231 => {
+                    let convert = |value: u8| -> u8 {
+                        match value {
+                            0 => 0,
+                            _ => value * 0x28 + 0x28
+                        }
+                    };
 
-                let r = convert((value - 16)/36 % 6);
-                let g = convert((value - 16)/6 % 6);
-                let b = convert((value - 16) % 6);
-                Color::new(r, g, b)
-            },
-            232 ... 255 => {
-                let gray = (value - 232) * 10 + 8;
-                Color::new(gray, gray, gray)
-            },
-            _ => Color::new(0, 0, 0)
+                    let r = convert((value - 16) / 36 % 6);
+                    let g = convert((value - 16) / 6 % 6);
+                    let b = convert((value - 16) % 6);
+                    encode_rgb(r, g, b)
+                },
+                232 ... 255 => {
+                    let gray = (value - 232) * 10 + 8;
+                    encode_rgb(gray, gray, gray)
+                },
+                _ => encode_rgb(0, 0, 0)
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,8 +89,8 @@ impl Console {
             bottom_margin: cmp::max(0, h as isize - 1) as usize,
             g0: 'B',
             g1: '0',
-            foreground: Color::ansi(7),
-            background: Color::ansi(0),
+            foreground: Color::Ansi(7),
+            background: Color::Ansi(0),
             bold: false,
             inverted: false,
             underlined: false,
@@ -379,8 +379,8 @@ impl Console {
                         let value = value_str.parse::<u8>().unwrap_or(0);
                         match value {
                             0 => {
-                                self.foreground = Color::ansi(7);
-                                self.background = Color::ansi(0);
+                                self.foreground = Color::Ansi(7);
+                                self.background = Color::Ansi(0);
                                 self.bold = false;
                                 self.underlined = false;
                                 self.inverted = false;
@@ -403,43 +403,43 @@ impl Console {
                             27 => {
                                 self.inverted = false;
                             },
-                            30 ... 37 => self.foreground = Color::ansi(value - 30),
+                            30 ... 37 => self.foreground = Color::Ansi(value - 30),
                             38 => match value_iter.next().map_or("", |s| &s).parse::<usize>().unwrap_or(0) {
                                 2 => {
                                     //True color
                                     let r = value_iter.next().map_or("", |s| &s).parse::<u8>().unwrap_or(0);
                                     let g = value_iter.next().map_or("", |s| &s).parse::<u8>().unwrap_or(0);
                                     let b = value_iter.next().map_or("", |s| &s).parse::<u8>().unwrap_or(0);
-                                    self.foreground = Color::new(r, g, b);
+                                    self.foreground = Color::TrueColor(r, g, b);
                                 },
                                 5 => {
                                     //256 color
                                     let color_value = value_iter.next().map_or("", |s| &s).parse::<u8>().unwrap_or(0);
-                                    self.foreground = Color::ansi(color_value);
+                                    self.foreground = Color::Ansi(color_value);
                                 },
                                 _ => {}
                             },
                             39 => {
-                                self.foreground = Color::ansi(7);
+                                self.foreground = Color::Ansi(7);
                             },
-                            40 ... 47 => self.background = Color::ansi(value - 40),
+                            40 ... 47 => self.background = Color::Ansi(value - 40),
                             48 => match value_iter.next().map_or("", |s| &s).parse::<usize>().unwrap_or(0) {
                                 2 => {
                                     //True color
                                     let r = value_iter.next().map_or("", |s| &s).parse::<u8>().unwrap_or(0);
                                     let g = value_iter.next().map_or("", |s| &s).parse::<u8>().unwrap_or(0);
                                     let b = value_iter.next().map_or("", |s| &s).parse::<u8>().unwrap_or(0);
-                                    self.background = Color::new(r, g, b);
+                                    self.background = Color::TrueColor(r, g, b);
                                 },
                                 5 => {
                                     //256 color
                                     let color_value = value_iter.next().map_or("", |s| &s).parse::<u8>().unwrap_or(0);
-                                    self.background = Color::ansi(color_value);
+                                    self.background = Color::Ansi(color_value);
                                 },
                                 _ => {}
                             },
                             49 => {
-                                self.background = Color::ansi(0);
+                                self.background = Color::Ansi(0);
                             },
                             _ => {},
                         }
@@ -679,8 +679,8 @@ impl Console {
                     self.cursor = true;
                     self.g0 = 'B';
                     self.g1 = '0';
-                    self.foreground = Color::ansi(7);
-                    self.background = Color::ansi(0);
+                    self.foreground = Color::Ansi(7);
+                    self.background = Color::Ansi(0);
                     self.bold = false;
                     self.inverted = false;
                     self.underlined = false;


### PR DESCRIPTION
This change enables the implementation of custom color schemes in Orbterm later on.